### PR TITLE
Update site.py

### DIFF
--- a/pyadtpulse/site.py
+++ b/pyadtpulse/site.py
@@ -103,7 +103,7 @@ class ADTPulseSite(object):
                 self._status = ADT_ALARM_OFF
             elif re.match('Armed Away', text):
                 self._status = ADT_ALARM_AWAY
-            elif re.match('Armed Home', text):
+            elif re.match('Armed Stay', text):
                 self._status = ADT_ALARM_HOME
             else:
                 LOG.warning(f"Failed to get alarm status from '{text}'")


### PR DESCRIPTION
Noticed "Armed Home" is used to match with status text. Updated to "Armed Stay" to reflect verbiage on ADTPulse portal.