### PR TITLE
Bump uvloop to 0.17

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 beautifulsoup4>=4.11.1
 aiohttp>=3.8.1
 python_dateutil>=2.8.2
-uvloop>=0.16.0
+uvloop>=0.17.0

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
     author="",
     author_email="",
     license="Apache Software License",
-    install_requires=["aiohttp>=3.8.1", "uvloop==0.16.0"],
+    install_requires=["aiohttp>=3.8.1", "uvloop>=0.17.0"],
     keywords=["security system", "adt", "home automation", "security alarm"],
     zip_safe=True,
     classifiers=[


### PR DESCRIPTION
1.0.3 doesn't install from pypi because uvloop tries to downgrade to 0.16